### PR TITLE
Bugfix: Make the syncdb not execute on every run

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -104,6 +104,7 @@ class graphite_web::config (
       exec { 'fill postgresql database':
         command => '/bin/graphite-manage syncdb --noinput',
         cwd     => "${graphite_root}/webapp",
+        unless  => "/bin/bash -c '[[ $(graphite-manage inspectdb | wc -l) -gt 13 ]]'",
         require => [Concat::Fragment['graphite_web config database configuration'],
                         Package['python-psycopg2']]
       }

--- a/metadata.json
+++ b/metadata.json
@@ -5,8 +5,8 @@
   "summary": "Installs, configures and manages graphite web.",
   "license": "Apache-2.0",
   "source": "",
-  "project_page": null,
-  "issues_url": null,
+  "project_page": "https://github.com/marclambrichs/puppet-graphite_web",
+  "issues_url": "https://github.com/marclambrichs/puppet-graphite_web/issues",
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",


### PR DESCRIPTION
The syncdb command in the exec 'fill postgresql database' is executed on every run.
This pull request adds an unless attribute to check if the database was provisioned.
As the 'graphite-manage inspectdb' command will return the tables that are in it.

If the syncdb command did not run it just returns the django header:
```bash
[root@graphite ~]# graphite-manage inspectdb
# This is an auto-generated Django model module.
# You'll have to do the following manually to clean this up:
#   * Rearrange models' order
#   * Make sure each model has one field with primary_key=True
#   * Remove `managed = False` lines if you wish to allow Django to create and delete the table
# Feel free to rename the models, but don't rename db_table values or field names.
#
# Also note: You'll have to insert the output of 'django-admin.py sqlcustom [appname]'
# into your database.
from __future__ import unicode_literals

from django.db import models

[root@graphite ~]# graphite-manage inspectdb | wc -l
13
```

Once it has run it lists all the classes and tables:
```bash
[root@graphite ~]# graphite-manage inspectdb | wc -l
197

[root@graphite ~]# graphite-manage inspectdb
# This is an auto-generated Django model module.
# You'll have to do the following manually to clean this up:
#   * Rearrange models' order
#   * Make sure each model has one field with primary_key=True
#   * Remove `managed = False` lines if you wish to allow Django to create and delete the table
# Feel free to rename the models, but don't rename db_table values or field names.
#
# Also note: You'll have to insert the output of 'django-admin.py sqlcustom [appname]'
# into your database.
from __future__ import unicode_literals

from django.db import models

class AccountMygraph(models.Model):
    id = models.IntegerField(primary_key=True)
    profile = models.ForeignKey('AccountProfile')
    name = models.CharField(max_length=64)
    url = models.TextField()
    class Meta:
        managed = False
....
```

This can be checked with bash:
```bash
[root@graphite ~]# bash -c '[[ $(graphite-manage inspectdb | wc -l) -gt 13 ]]'
[root@graphite ~]# echo $?
1

#syncdb

[root@graphite ~]# bash -c '[[ $(graphite-manage inspectdb | wc -l) -gt 13 ]]'
[root@graphite ~]# echo $?
0
```

Not the cleanest way but now the exec does only run when needed.

Signed-off-by: bjanssens <bjanssens@inuits.eu>